### PR TITLE
Make end-of-example transaction rollback conditional

### DIFF
--- a/lib/slacker/application.rb
+++ b/lib/slacker/application.rb
@@ -162,7 +162,7 @@ EOF
       end
 
       after_proc = lambda do |example|
-        Slacker.query_script(example, 'rollback transaction;', 'Rollback the changes made by the example script')
+        Slacker.query_script(example, 'if @@trancount > 0 rollback transaction;', 'Rollback the changes made by the example script')
       end
 
       # Reset RSpec through a monkey-patched method

--- a/lib/slacker/version.rb
+++ b/lib/slacker/version.rb
@@ -1,3 +1,3 @@
 module Slacker
-  VERSION = "1.0.13"
+  VERSION = "1.0.14"
 end


### PR DESCRIPTION
Make sure that the transaction we are rolling back at the end of each test is still there and it's not already rolled back by application code.