### PR TITLE
Complete husekeeping

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 Behavior Driven Development for SQL Server
 
-Slacker is a transacted RSpec-based framework for developing automated tests for SQL Server 2005-2014 programmable objects such as stored procedures, scalar/table functions, triggers, etc.
+Slacker is a transacted RSpec-based framework for developing automated tests for SQL Server 2005-2017 programmable objects such as stored procedures, scalar/table functions, triggers, etc.
 
 # Resources
 

--- a/lib/slacker/application.rb
+++ b/lib/slacker/application.rb
@@ -159,8 +159,12 @@ EOF
 
     def configure_db_tiny_tds
       begin
-        @database = TinyTds::Client.new :username => @configuration.db_user, :password => @configuration.db_password, 
-                    :host => @configuration.db_server, :database => @configuration.db_name, :port => @configuration.db_port
+        @database = TinyTds::Client.new :username => @configuration.db_user,
+                      :password => @configuration.db_password, 
+                      :host => @configuration.db_server,
+                      :database => @configuration.db_name,
+                      :port => @configuration.db_port
+                      
         @database.query_options[:symbolize_keys] = true
       rescue TinyTds::Error => e
         throw_error("#{e}")

--- a/lib/slacker/version.rb
+++ b/lib/slacker/version.rb
@@ -1,3 +1,3 @@
 module Slacker
-  VERSION = "1.0.16"
+  VERSION = "1.0.17"
 end

--- a/lib/slacker_new/project/database.yml
+++ b/lib/slacker_new/project/database.yml
@@ -4,11 +4,19 @@
 # Replace the following with your connection information.
 # Note that at this point Slacker only works with SQL Server authentication.
 
-# Slacker supports odbc and tiny_tds drivers
+# Slacker supports odbc and tiny_tds drivers.
 
-server: my_server
+# odbc or tiny_tds; defaults to odbc.
+driver: odbc
+
+# Full instance name when using odbc; hostname or IP when using tiny_tds.
+server: my_server 
+
+# Used only when driver is set to tiny_tds.
+port: 1433 
+
 database: my_database
+
+# Slacker supports only SQL Server Auth.
 user: user_name
 password: password
-port: 1433
-driver: odbc #or tiny_tds

--- a/slacker.gemspec
+++ b/slacker.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables = ['slacker', 'slacker_new']
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = '>= 1.9.2'
+  s.required_ruby_version = '>= 2.0.0'
  
   s.add_dependency 'bundler', '~> 1.0', '>= 1.0.15'
   s.add_dependency 'ruby-odbc', '= 0.99998'


### PR DESCRIPTION
Update README to add support for SQL Server 2017
Update requirements to require Ruby 2.0.0
Add TDS-related comments to scaffold database.yml