### PR TITLE
fix for issue #21 and #22

### DIFF
--- a/bin/slacker
+++ b/bin/slacker
@@ -23,12 +23,10 @@ Slacker.configure do |config|
   config.db_name = db_config["database"]
   config.db_user = db_config["user"]
   config.db_password = db_config["password"]
-  if !!db_config["port"] 
-    config.db_port = db_config["port"] 
-  end
-  if !!db_config["driver"] 
-    config.db_driver = db_config["driver"] 
-  end
+  config.db_port = db_config["port"] if !!db_config["port"] 
+  config.db_driver = db_config["driver"] if !!db_config["driver"] 
+  # Override console_enabled value with the value from configuration yaml
+  config.console_enabled = db_config["console_enabled"] if db_config["console_enabled"] != nil
 end
 
 if Slacker.application.run

--- a/lib/slacker/application.rb
+++ b/lib/slacker/application.rb
@@ -247,7 +247,7 @@ EOF
         config.output_stream = @configuration.output_stream
         config.error_stream = @configuration.error_stream
 
-        config.add_formatter(Slacker::CommandLineFormatter)
+        config.add_formatter(Slacker::CommandLineFormatter) if @configuration.console_enabled
      end
     end
 

--- a/lib/slacker/configuration.rb
+++ b/lib/slacker/configuration.rb
@@ -27,15 +27,9 @@ module Slacker
 
     def console_enabled=(value)
       @console_enabled = value
-      if @console_enabled
-        @error_stream = $stderr
-        @output_stream = $stdout
-        @rspec_args = ARGV
-      else
-        @error_stream = nil
-        @output_stream = nil
-        @rspec_args = []
-      end
+      @error_stream = $stderr
+      @output_stream = $stdout
+      @rspec_args = ARGV
     end
 
     def rspec_args


### PR DESCRIPTION
The goal is to enhance Slacker to allow developers to build a Slacker Runner Service in any language and platform by directly providing the test result in an application consumable format including HTML and JSON without regex-ing it.

Values: 

- Slacker Runner development is simpler since Slacker itself provides HTML / JSON out directly.
- Knowing that running all spec rb files by specifying the root folder is faster  than running individual spec file e.g. 0.0563 second vs 3 second in a test env.  Now slacker with -fj -fd -fh options returns the full test result details.

Change list:
1. Added a temporary / hidden flag console_enabled properties in database.yaml.
2. Changed Slacker::CommandLineFormatter to be active only when console_enabled option is true so that HTML or JSON output format does not contain console output strings.
3. @error_stream @output_stream @rspec_args are required for both console_enabled is true and false hence removed the if condition check in configuration.rb 