### PR TITLE
Default the scaffolded project driver to `odbc`

### DIFF
--- a/lib/slacker/version.rb
+++ b/lib/slacker/version.rb
@@ -1,3 +1,3 @@
 module Slacker
-  VERSION = "1.0.18"
+  VERSION = "1.0.19"
 end

--- a/lib/slacker_new/project/database.yml
+++ b/lib/slacker_new/project/database.yml
@@ -1,12 +1,14 @@
 # Database connection.
 
 # Slacker supports odbc and tiny_tds.
-# tiny_tds is recommended.
 # When not set, driver defaults to odbc for backward compatibility.
-driver: tiny_tds
+# The odbc driver is easier to set up on Windows, but tiny_tds is recommended
+# if you intend to run slacker cross-platform.
+# See https://github.com/vassilvk/slacker/wiki/Slacker-Project#odbc-vs-tds for more information.
+driver: odbc
 
 # Full instance name when using odbc; hostname or IP when using tiny_tds.
-server: localhost 
+server: my_server
 
 # Port is used by tiny_tds only. Defaults to 1433 when not set.
 # Use server and port when targeting named instances with tiny_tds.


### PR DESCRIPTION
Closes #25 