### PR TITLE
Upgrade ruby-odbc to 0.99999

### DIFF
--- a/lib/slacker/version.rb
+++ b/lib/slacker/version.rb
@@ -1,3 +1,3 @@
 module Slacker
-  VERSION = "1.0.22"
+  VERSION = "1.0.23"
 end

--- a/slacker.gemspec
+++ b/slacker.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
  
   s.add_dependency 'bundler', '~> 1.0', '>= 1.0.15'
-  s.add_dependency 'ruby-odbc', '= 0.99998'
+  s.add_dependency 'ruby-odbc', '= 0.99999'
   s.add_dependency 'rspec', '~> 3.0'
   s.add_dependency 'tiny_tds', '~>2.0'
 end


### PR DESCRIPTION
Fixes #36.

ruby-odbc 0.99999 includes fixes which enable this gem on Ruby 2.4 and higher.